### PR TITLE
Add error handling for gainers

### DIFF
--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 from pyminion.bots.bot import Bot
 from pyminion.core import AbstractDeck, Action, Card, Treasure, Victory
 from pyminion.decisions import validate_input
-from pyminion.exceptions import InvalidMultiCardInput, InvalidSingleCardInput
+from pyminion.exceptions import (EmptyPile, InvalidMultiCardInput,
+                                 InvalidSingleCardInput)
 from pyminion.players import Human, Player
 
 if TYPE_CHECKING:
@@ -826,10 +827,15 @@ class Witch(Action):
         for opponent in game.players:
             if opponent is not player:
                 if opponent.is_attacked(player=player, attack_card=self):
-                    opponent.gain(
-                        card=curse,
-                        supply=game.supply,
-                    )
+
+                    # attempt to gain a curse. if curse pile is empty, proceed
+                    try:
+                        opponent.gain(
+                            card=curse,
+                            supply=game.supply,
+                        )
+                    except EmptyPile:
+                        pass
 
 
 class Moat(Action):
@@ -917,7 +923,11 @@ class Bandit(Action):
         if generic_play:
             super().generic_play(player)
 
-        player.gain(card=gold, supply=game.supply)
+        # attempt to gain a gold. if gold pile is empty, proceed
+        try:
+            player.gain(card=gold, supply=game.supply)
+        except EmptyPile:
+            pass
 
         for opponent in game.players:
             if opponent is not player:
@@ -970,7 +980,11 @@ class Bureaucrat(Action):
         if generic_play:
             super().generic_play(player)
 
-        player.gain(card=silver, supply=game.supply, destination=player.deck)
+        # attempt to gain a silver. if silver pile is empty, proceed
+        try:
+            player.gain(card=silver, supply=game.supply, destination=player.deck)
+        except EmptyPile:
+            pass
 
         for opponent in game.players:
             if opponent is not player and opponent.is_attacked(

--- a/tests/test_cards/test_actions/test_bandit.py
+++ b/tests/test_cards/test_actions/test_bandit.py
@@ -1,5 +1,6 @@
+from pyminion.expansions.base import (Bandit, Gold, Silver, bandit, copper,
+                                      gold, silver)
 from pyminion.game import Game
-from pyminion.expansions.base import Bandit, Gold, Silver, bandit, copper, gold, silver
 
 
 def test_bandit_gains_gold(multiplayer_game: Game):
@@ -55,3 +56,26 @@ def test_bandit_discard_two_non_treasure(multiplayer_game: Game):
     player.hand.cards[-1].play(player, multiplayer_game)
     assert len(multiplayer_game.trash) == 0
     assert len(opponent.discard_pile) == 2
+
+
+def test_bandit_empty_gold(multiplayer_game: Game):
+    """
+    with an empty gold pile, playing witch should only trash opponents cards
+
+    """
+
+    # empty the gold pile
+    for pile in multiplayer_game.supply.piles:
+        if pile.name == "gold":
+            pile.cards = []
+
+    player = multiplayer_game.players[0]
+    player.hand.add(bandit)
+    player.hand.cards[-1].play(player, multiplayer_game)
+
+    assert len(player.discard_pile) == 0
+    assert len(player.playmat) == 1
+    assert type(player.playmat.cards[0]) is Bandit
+    assert player.state.actions == 0
+    assert player.state.money == 0
+    assert player.state.buys == 1

--- a/tests/test_cards/test_actions/test_bandit.py
+++ b/tests/test_cards/test_actions/test_bandit.py
@@ -66,7 +66,7 @@ def test_bandit_empty_gold(multiplayer_game: Game):
 
     # empty the gold pile
     for pile in multiplayer_game.supply.piles:
-        if pile.name == "gold":
+        if pile.name == "Gold":
             pile.cards = []
 
     player = multiplayer_game.players[0]

--- a/tests/test_cards/test_actions/test_bureaucrat.py
+++ b/tests/test_cards/test_actions/test_bureaucrat.py
@@ -47,7 +47,7 @@ def test_bureaucrat_opponent_no_victory(multiplayer_game: Game, monkeypatch):
     assert len(opponent.hand) == opp_hand_len
 
 
-def test_bureaucrat_empty_silver(multiplayer_game: Game):
+def test_bureaucrat_empty_silver(multiplayer_game: Game, monkeypatch):
     """
     with an empty silver pile, playing bureaucrat should only attack opponents
 
@@ -60,6 +60,8 @@ def test_bureaucrat_empty_silver(multiplayer_game: Game):
 
     player = multiplayer_game.players[0]
     player.hand.add(bureaucrat)
+
+    monkeypatch.setattr("builtins.input", lambda _: "Estate")
     player.hand.cards[-1].play(player, multiplayer_game)
 
     assert len(player.discard_pile) == 0

--- a/tests/test_cards/test_actions/test_bureaucrat.py
+++ b/tests/test_cards/test_actions/test_bureaucrat.py
@@ -55,7 +55,7 @@ def test_bureaucrat_empty_silver(multiplayer_game: Game):
 
     # empty the silver pile
     for pile in multiplayer_game.supply.piles:
-        if pile.name == "silver":
+        if pile.name == "Silver":
             pile.cards = []
 
     player = multiplayer_game.players[0]

--- a/tests/test_cards/test_actions/test_bureaucrat.py
+++ b/tests/test_cards/test_actions/test_bureaucrat.py
@@ -1,11 +1,5 @@
-from pyminion.expansions.base import (
-    Bureaucrat,
-    Estate,
-    Silver,
-    bureaucrat,
-    copper,
-    estate,
-)
+from pyminion.expansions.base import (Bureaucrat, Estate, Silver, bureaucrat,
+                                      copper, estate)
 from pyminion.game import Game
 
 
@@ -51,3 +45,26 @@ def test_bureaucrat_opponent_no_victory(multiplayer_game: Game, monkeypatch):
 
     player.hand.cards[-1].play(player, multiplayer_game)
     assert len(opponent.hand) == opp_hand_len
+
+
+def test_bureaucrat_empty_silver(multiplayer_game: Game):
+    """
+    with an empty silver pile, playing bureaucrat should only attack opponents
+
+    """
+
+    # empty the silver pile
+    for pile in multiplayer_game.supply.piles:
+        if pile.name == "silver":
+            pile.cards = []
+
+    player = multiplayer_game.players[0]
+    player.hand.add(bureaucrat)
+    player.hand.cards[-1].play(player, multiplayer_game)
+
+    assert len(player.discard_pile) == 0
+    assert len(player.playmat) == 1
+    assert type(player.playmat.cards[0]) is Bureaucrat
+    assert player.state.actions == 0
+    assert player.state.money == 0
+    assert player.state.buys == 1

--- a/tests/test_cards/test_actions/test_witch.py
+++ b/tests/test_cards/test_actions/test_witch.py
@@ -30,7 +30,7 @@ def test_witch_empty_curses(multiplayer_game: Game):
 
     # empty the curse pile
     for pile in multiplayer_game.supply.piles:
-        if pile.name == "curse":
+        if pile.name == "Curse":
             pile.cards = []
 
     player = multiplayer_game.players[0]

--- a/tests/test_cards/test_actions/test_witch.py
+++ b/tests/test_cards/test_actions/test_witch.py
@@ -1,5 +1,5 @@
-from pyminion.game import Game
 from pyminion.expansions.base import Witch, curse, witch
+from pyminion.game import Game
 
 
 def test_witch(multiplayer_game: Game):
@@ -14,6 +14,32 @@ def test_witch(multiplayer_game: Game):
         if p is not player:
             assert len(p.discard_pile) == 1
             assert p.discard_pile.cards[-1] is curse
+    assert len(player.hand) == 7
+    assert len(player.playmat) == 1
+    assert type(player.playmat.cards[0]) is Witch
+    assert player.state.actions == 0
+    assert player.state.money == 0
+    assert player.state.buys == 1
+
+
+def test_witch_empty_curses(multiplayer_game: Game):
+    """
+    with an empty curse pile, playing witch should only draw two cards and not give out any curses.
+
+    """
+
+    # empty the curse pile
+    for pile in multiplayer_game.supply.piles:
+        if pile.name == "curse":
+            pile.cards = []
+
+    player = multiplayer_game.players[0]
+    player.hand.add(witch)
+    player.hand.cards[-1].play(player, multiplayer_game)
+
+    for p in multiplayer_game.players:
+        if p is not player:
+            assert len(p.discard_pile) == 0
     assert len(player.hand) == 7
     assert len(player.playmat) == 1
     assert type(player.playmat.cards[0]) is Witch


### PR DESCRIPTION
Close #87 

Previously, certain gainer cards that gained unconditionally (`witch`,`bandit`,`bureaucrat`), would throw an error if the pile of the card they were trying to gain was empty. 

This PR changes that behavior so no error is thrown, and action proceeds ignoring the gain affect.