### PR TITLE
Fixing DeckCounter issue when counting a player's starting deck

### DIFF
--- a/pyminion/game.py
+++ b/pyminion/game.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import random
 from typing import List, Optional
@@ -186,7 +185,7 @@ class Game:
 
         for player in self.players:
             player.reset()
-            player.discard_pile = Deck(copy.deepcopy(self.start_deck))
+            player.discard_pile = Deck(self.start_deck[:])
             logger.info(f"\n{player} starts with {player.discard_pile}")
             player.draw(5)
 

--- a/tests/test_core/test_deck_counter.py
+++ b/tests/test_core/test_deck_counter.py
@@ -1,0 +1,32 @@
+from pyminion.core import Deck, DeckCounter
+from pyminion.expansions.base import base_set, copper, estate
+from pyminion.game import Game
+from pyminion.players import Human, Player
+from typing import List
+
+
+def test_deck_counter_no_args():
+    deck_counter = DeckCounter()
+    assert str(deck_counter) == ""
+
+
+def test_deck_counter_empty():
+    deck = Deck()
+    deck_counter = DeckCounter(deck.cards)
+    assert str(deck_counter) == ""
+
+
+def test_deck_counter_starting_cards():
+    players: List[Player] = [Human(player_id=f"human{i}") for i in range(2)]
+    game = Game(players, [base_set])
+    game.start()
+    player1 = game.players[0]
+
+    deck_counter1 = DeckCounter(player1.get_all_cards())
+    assert str(deck_counter1) == "7 Copper, 3 Estate"
+
+    player1.gain(copper, game.supply)
+    player1.gain(estate, game.supply)
+
+    deck_counter2 = DeckCounter(player1.get_all_cards())
+    assert str(deck_counter2) == "8 Copper, 4 Estate"


### PR DESCRIPTION
Fixing #78 where `DeckCounter` was not properly counting the cards that start in a player's deck. The issue was a `deepcopy` on a list that was creating new instances of cards. I changed the code to make a new list copy but not copy the card instances in the list.