### PR TITLE
Card number fix

### DIFF
--- a/pyminion/core.py
+++ b/pyminion/core.py
@@ -45,6 +45,9 @@ class Card:
         cost = max(0, self._cost - game.card_cost_reduction)
         return cost
 
+    def get_pile_starting_count(self, game: "Game") -> int:
+        return 10
+
 
 class ScoreCard(Card):
     def __init__(self, name: str, cost: int, type: Tuple[CardType, ...]):
@@ -61,6 +64,15 @@ class ScoreCard(Card):
 class Victory(ScoreCard):
     def __init__(self, name: str, cost: int, type: Tuple[CardType, ...]):
         super().__init__(name, cost, type)
+
+    def get_pile_starting_count(self, game: "Game") -> int:
+        num_players = len(game.players)
+        if num_players == 1:
+            return 5
+        elif num_players == 2:
+            return 8
+        else:
+            return 12
 
 
 class Treasure(Card):

--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -23,6 +23,10 @@ class Copper(Treasure):
     ):
         super().__init__(name, cost, type, money)
 
+    def get_pile_starting_count(self, game: "Game") -> int:
+        num_players = len(game.players)
+        return 60 - (7 * num_players)
+
     def play(self, player: Player, game: "Game") -> None:
         player.playmat.add(self)
         player.hand.remove(self)
@@ -38,6 +42,9 @@ class Silver(Treasure):
         money: int = 2,
     ):
         super().__init__(name, cost, type, money)
+
+    def get_pile_starting_count(self, game: "Game") -> int:
+        return 40
 
     def play(self, player: Player, game: "Game") -> None:
 
@@ -62,6 +69,9 @@ class Gold(Treasure):
         money: int = 3,
     ):
         super().__init__(name, cost, type, money)
+
+    def get_pile_starting_count(self, game: "Game") -> int:
+        return 30
 
     def play(self, player: Player, game: "Game") -> None:
         player.playmat.add(self)
@@ -119,6 +129,17 @@ class Curse(ScoreCard):
         type: Tuple[CardType, ...] = (CardType.Curse,),
     ):
         super().__init__(name, cost, type)
+
+    def get_pile_starting_count(self, game: "Game") -> int:
+        num_players = len(game.players)
+        if num_players == 1:
+            return 10
+        elif num_players == 2:
+            return 10
+        elif num_players == 3:
+            return 20
+        else:
+            return 30
 
     def score(self, player: Player) -> int:
         vp = -1

--- a/pyminion/game.py
+++ b/pyminion/game.py
@@ -2,7 +2,7 @@ import logging
 import random
 from typing import List, Optional
 
-from pyminion.core import CardType, Card, DeckCounter, DiscardPile, Pile, Supply, Trash
+from pyminion.core import Card, DeckCounter, DiscardPile, Pile, Supply, Trash
 from pyminion.exceptions import InvalidGameSetup, InvalidPlayerCount
 from pyminion.expansions.base import (copper, curse, duchy, estate, gold,
                                       province, silver)
@@ -75,30 +75,7 @@ class Game:
 
         """
 
-        if len(self.players) == 1:
-            VICTORY_LENGTH = 5
-            CURSE_LENGTH = 10
-            COPPER_LENGTH = 53
-
-        elif len(self.players) == 2:
-            VICTORY_LENGTH = 8
-            CURSE_LENGTH = 10
-            COPPER_LENGTH = 46
-
-        elif len(self.players) == 3:
-            VICTORY_LENGTH = 12
-            CURSE_LENGTH = 20
-            COPPER_LENGTH = 39
-
-        else:
-            VICTORY_LENGTH = 12
-            CURSE_LENGTH = 30
-            COPPER_LENGTH = 32
-
-        SILVER_LENGTH = 40
-        GOLD_LENGTH = 30
-
-        basic_cards = [
+        basic_cards: List[Card] = [
             copper,
             silver,
             gold,
@@ -108,18 +85,10 @@ class Game:
             curse,
         ]
 
-        basic_piles = []
-        for card in basic_cards:
-            if card.name == "Copper":
-                basic_piles.append(Pile([card] * COPPER_LENGTH))
-            elif card.name == "Silver":
-                basic_piles.append(Pile([card] * SILVER_LENGTH))
-            elif card.name == "Gold":
-                basic_piles.append(Pile([card] * GOLD_LENGTH))
-            elif CardType.Victory in card.type:
-                basic_piles.append(Pile([card] * VICTORY_LENGTH))
-            elif CardType.Curse in card.type:
-                basic_piles.append(Pile([card] * CURSE_LENGTH))
+        basic_piles = [
+            Pile([card] * card.get_pile_starting_count(self))
+            for card in basic_cards
+        ]
 
         return basic_piles
 
@@ -129,7 +98,6 @@ class Game:
         This should be 10 piles each with 10 cards.
 
         """
-        PILE_LENGTH: int = 10
         KINGDOM_PILES: int = 10
 
         # All available cards from chosen expansions
@@ -149,7 +117,7 @@ class Game:
             chosen_cards = 0
 
         chosen_piles = (
-            [Pile([card] * PILE_LENGTH) for card in self.kingdom_cards]
+            [Pile([card] * card.get_pile_starting_count(self)) for card in self.kingdom_cards]
             if chosen_cards
             else []
         )
@@ -158,7 +126,7 @@ class Game:
             for card in self.kingdom_cards:
                 kingdom_options.remove(card)  # Do not duplicate any user chosen cards
         kingdom_ten = random.sample(kingdom_options, KINGDOM_PILES - chosen_cards)
-        random_piles = [Pile([card] * PILE_LENGTH) for card in kingdom_ten]
+        random_piles = [Pile([card] * card.get_pile_starting_count(self)) for card in kingdom_ten]
 
         return chosen_piles + random_piles
 

--- a/tests/test_core/test_core_functions.py
+++ b/tests/test_core/test_core_functions.py
@@ -1,7 +1,11 @@
-from pyminion.core import get_action_cards, get_treasure_cards, get_victory_cards, get_score_cards
+from pyminion.core import Action, CardType, Victory, get_action_cards, get_treasure_cards, get_victory_cards, get_score_cards
 from pyminion.expansions.base import gold, silver, copper, province, duchy, estate, curse, market, smithy
 from pyminion.expansions.intrigue import nobles
+from pyminion.game import Game
+from pyminion.player import Player
 
+test_action = Action("test", 1, (CardType.Action,))
+test_victory = Victory("test", 1, (CardType.Victory,))
 
 def test_get_action_cards():
     cards_in = [
@@ -78,3 +82,24 @@ def test_get_score_cards():
     assert cards_out[1].name == "Province"
     assert cards_out[2].name == "Duchy"
     assert cards_out[3].name == "Nobles"
+
+
+def test_action_card_starting_count(player: Player):
+    players = [player] * 2
+    game = Game(players, [])
+
+    assert test_action.get_pile_starting_count(game) == 10
+
+
+def test_victory_card_start_count_2_players(player: Player):
+    players = [player] * 2
+    game = Game(players, [])
+
+    assert test_victory.get_pile_starting_count(game) == 8
+
+
+def test_victory_card_start_count_3_players(player: Player):
+    players = [player] * 3
+    game = Game(players, [])
+
+    assert test_victory.get_pile_starting_count(game) == 12


### PR DESCRIPTION
This addresses issue #97. It adds a new `Card` member function `get_pile_starting_count()` that returns 10 by default, but can be overridden to have a different number of starting cards. I updated victory cards and some other supply piles (e.g. copper, curses, etc.) to use this member function. It will also be useful in the future for other piles that do not start with 10 cards (e.g. [Port](https://wiki.dominionstrategy.com/index.php/Port), [Rats](https://wiki.dominionstrategy.com/index.php/Rats), etc.).

I noticed there was logic for the number of victory cards with 1 player. I ported this logic to the new method, but I wasn't sure what exactly it was for or whether it was still needed.