### PR TITLE
Various Bug Fixes and Improvements

### DIFF
--- a/pyminion/bots/examples/big_money.py
+++ b/pyminion/bots/examples/big_money.py
@@ -16,6 +16,9 @@ class BigMoneyDecider(BotDecider):
 
     """
 
+    def action_priority(self, player: Player, game: Game) -> Iterator[Card]:
+        return iter([])
+
     def buy_priority(self, player: Player, game: Game) -> Iterator[Card]:
         money = player.state.money
         if money >= 8:

--- a/pyminion/bots/optimized_bot.py
+++ b/pyminion/bots/optimized_bot.py
@@ -263,6 +263,9 @@ class OptimizedBotDecider(BotDecider):
             return self.chapel(player=player, game=game, valid_cards=valid_cards)
         elif card.name == "Sentry":
             return self.sentry(player=player, game=game, valid_cards=valid_cards, trash=True)
+        elif card.name == "Bandit":
+            ret = self.bandit(player, game, valid_cards)
+            return [ret]
         elif card.name == "Lurker":
             ret = self.lurker(player, game, valid_cards, trash=True)
             return [ret]
@@ -681,6 +684,15 @@ class OptimizedBotDecider(BotDecider):
         # Double play most expensive card
         max_price_card = max(valid_cards, key=lambda card: card.get_cost(player, game))
         return max_price_card
+
+    def bandit(
+        self,
+        player: "Player",
+        game: "Game",
+        valid_cards: List[Card],
+    ) -> Card:
+        min_price_card = min(valid_cards, key=lambda card: card.get_cost(player, game))
+        return min_price_card
 
     def baron(
         self,

--- a/pyminion/bots/optimized_bot.py
+++ b/pyminion/bots/optimized_bot.py
@@ -632,7 +632,7 @@ class OptimizedBotDecider(BotDecider):
             else:
                 return player.hand.cards[-1]
         if gain:
-            if game.supply.pile_length(pile_name="Province") < 5:
+            if game.supply.pile_length("Province") < 5 and game.supply.pile_length("Duchy") > 0:
                 return duchy
             else:
                 return silver
@@ -646,7 +646,7 @@ class OptimizedBotDecider(BotDecider):
         player: "Player",
         game: "Game",
     ) -> Card:
-        if game.supply.pile_length(pile_name="Province") < 3:
+        if game.supply.pile_length("Province") < 3 and game.supply.pile_length("Estate") > 0:
             return estate
         else:
             return silver

--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -926,17 +926,23 @@ class Remodel(Action):
 
         super().play(player, game, generic_play)
 
-        trash_cards = player.decider.trash_decision(
-            prompt="Trash a card from your hand: ",
-            card=self,
-            valid_cards=player.hand.cards,
-            player=player,
-            game=game,
-            min_num_trash=1,
-            max_num_trash=1,
-        )
-        assert len(trash_cards) == 1
-        trash_card = trash_cards[0]
+        if len(player.hand) == 0:
+            return
+
+        if len(player.hand) == 1:
+            trash_card = player.hand.cards[0]
+        else:
+            trash_cards = player.decider.trash_decision(
+                prompt="Trash a card from your hand: ",
+                card=self,
+                valid_cards=player.hand.cards,
+                player=player,
+                game=game,
+                min_num_trash=1,
+                max_num_trash=1,
+            )
+            assert len(trash_cards) == 1
+            trash_card = trash_cards[0]
 
         max_cost = trash_card.get_cost(player, game) + 2
         gain_cards = player.decider.gain_decision(

--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -2,7 +2,7 @@ import logging
 import math
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from pyminion.core import AbstractDeck, CardType, Action, Card, ScoreCard, Treasure, Victory
+from pyminion.core import AbstractDeck, CardType, Action, Card, ScoreCard, Treasure, Victory, plural
 from pyminion.effects import AttackEffect, EffectAction, FuncPlayerCardGameEffect, FuncPlayerGameEffect, PlayerCardGameEffect
 from pyminion.player import Player
 
@@ -1113,21 +1113,26 @@ class Sentry(Action):
         looked_at = AbstractDeck()
         player.draw(num_cards=2, destination=looked_at, silent=True)
 
-        trash_cards = player.decider.trash_decision(
-            prompt="Enter the cards you would like to trash: ",
-            card=self,
-            valid_cards=looked_at.cards,
-            player=player,
-            game=game,
-            min_num_trash=0,
-            max_num_trash=2,
-        )
+        if len(looked_at) > 0:
+            s = plural("card", len(looked_at))
+            logger.info(f"Sentry {s}: {looked_at}")
+            trash_cards = player.decider.trash_decision(
+                prompt="Enter the cards you would like to trash: ",
+                card=self,
+                valid_cards=looked_at.cards,
+                player=player,
+                game=game,
+                min_num_trash=0,
+                max_num_trash=2,
+            )
 
-        for card in trash_cards:
-            looked_at.remove(card)
+            for card in trash_cards:
+                looked_at.remove(card)
 
         discard_cards: List[Card] = []
-        if len(looked_at.cards) > 0:
+        if len(looked_at) > 0:
+            s = plural("card", len(looked_at))
+            logger.info(f"Sentry {s}: {looked_at}")
             discard_cards = player.decider.discard_decision(
                 prompt="Enter the cards you would like to discard: ",
                 card=self,
@@ -1139,12 +1144,12 @@ class Sentry(Action):
                 looked_at.remove(card)
 
         reorder = False
-        if len(looked_at.cards) == 2:
+        if len(looked_at) == 2:
             logger.info(
                 f"Current order: {looked_at.cards[0]} (Top), {looked_at.cards[1]} (Bottom)"
             )
             reorder = player.decider.binary_decision(
-                prompt="Would you like to switch the order of the cards?",
+                prompt="Would you like to switch the order of the cards? y/n: ",
                 card=self,
                 player=player,
                 game=game,
@@ -1165,7 +1170,8 @@ class Sentry(Action):
             else:
                 for card in reversed(looked_at.cards):
                     player.deck.add(card)
-            logger.info(f"{player} topdecks {len(looked_at.cards)} cards")
+            s = plural("card", len(looked_at))
+            logger.info(f"{player} topdecks {len(looked_at)} {s}")
 
 
 class Library(Action):

--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -1113,6 +1113,7 @@ class Sentry(Action):
         looked_at = AbstractDeck()
         player.draw(num_cards=2, destination=looked_at, silent=True)
 
+        trash_cards: List[Card] = []
         if len(looked_at) > 0:
             s = plural("card", len(looked_at))
             logger.info(f"Sentry {s}: {looked_at}")

--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -1192,7 +1192,7 @@ class Library(Action):
         while len(player.hand) < 7:
 
             if len(player.deck) == 0 and len(player.discard_pile) == 0:
-                return
+                break
 
             player.draw(num_cards=1, destination=set_aside)
             drawn_card = set_aside.cards[-1]

--- a/pyminion/expansions/base.py
+++ b/pyminion/expansions/base.py
@@ -810,7 +810,7 @@ class Bandit(Action):
                     trash_card = trash_cards[0]
 
                 if trash_card is not None:
-                    player.trash(trash_card, game, revealed_cards)
+                    opponent.trash(trash_card, game, revealed_cards)
 
                 revealed_cards_copy = revealed_cards.cards[:]
                 for card in revealed_cards_copy:

--- a/pyminion/expansions/intrigue.py
+++ b/pyminion/expansions/intrigue.py
@@ -313,11 +313,11 @@ class Duke(Victory):
         return vp
 
 
-class Harem(Treasure, Victory):
+class Farm(Treasure, Victory):
     def __init__(self):
         Treasure.__init__(
             self,
-            name="Harem",
+            name="Farm",
             cost=6,
             type=(CardType.Treasure, CardType.Victory),
             money=2,
@@ -1296,7 +1296,7 @@ courtier = Courtier()
 courtyard = Courtyard()
 diplomat = Diplomat()
 duke = Duke()
-harem = Harem()
+farm = Farm()
 ironworks = Ironworks()
 lurker = Lurker()
 masquerade = Masquerade()
@@ -1325,7 +1325,7 @@ intrigue_set: List[Card] = [
     courtyard,
     diplomat,
     duke,
-    harem,
+    farm,
     ironworks,
     lurker,
     masquerade,

--- a/pyminion/expansions/intrigue.py
+++ b/pyminion/expansions/intrigue.py
@@ -910,17 +910,23 @@ class SecretPassage(Action):
 
         super().play(player, game, generic_play)
 
-        insert_cards = player.decider.topdeck_decision(
-            prompt="Enter the card you would like to insert in your deck: ",
-            card=self,
-            valid_cards=player.hand.cards,
-            player=player,
-            game=game,
-            min_num_topdeck=1,
-            max_num_topdeck=1,
-        )
-        assert len(insert_cards) == 1
-        insert_card = insert_cards[0]
+        if len(player.hand) == 0:
+            return
+
+        if len(player.hand) == 1:
+            insert_card = player.hand.cards[0]
+        else:
+            insert_cards = player.decider.topdeck_decision(
+                prompt="Enter the card you would like to insert in your deck: ",
+                card=self,
+                valid_cards=player.hand.cards,
+                player=player,
+                game=game,
+                min_num_topdeck=1,
+                max_num_topdeck=1,
+            )
+            assert len(insert_cards) == 1
+            insert_card = insert_cards[0]
 
         len_deck = len(player.deck)
         if len_deck == 0:

--- a/pyminion/expansions/intrigue.py
+++ b/pyminion/expansions/intrigue.py
@@ -1198,6 +1198,9 @@ class Upgrade(Action):
 
         super().play(player, game, generic_play)
 
+        if len(player.hand) == 0:
+            return
+
         trash_cards = player.decider.trash_decision(
             prompt="Trash a card from your hand: ",
             card=self,

--- a/pyminion/expansions/intrigue.py
+++ b/pyminion/expansions/intrigue.py
@@ -485,11 +485,11 @@ class Masquerade(Action):
         # prompt each player to choose a card to pass
         passed_cards: List[Card] = []
         for p in valid_players:
-            pass_cards = player.decider.pass_decision(
+            pass_cards = p.decider.pass_decision(
                 prompt="Pick a card to pass to the player on your left: ",
                 card=self,
                 valid_cards=p.hand.cards,
-                player=player,
+                player=p,
                 game=game,
                 min_num_pass=1,
                 max_num_pass=1,

--- a/pyminion/expansions/intrigue.py
+++ b/pyminion/expansions/intrigue.py
@@ -848,6 +848,9 @@ class Replace(Action):
 
         super().play(player, game, generic_play)
 
+        if len(player.hand) == 0:
+            return
+
         trash_cards = player.decider.trash_decision(
             prompt="Trash a card from your hand: ",
             card=self,

--- a/pyminion/player.py
+++ b/pyminion/player.py
@@ -250,7 +250,7 @@ class Player:
         self.state.buys -= 1
         self.discard_pile.add(card)
         self.current_turn_gains.append((game.current_phase, card))
-        game.effect_registry.on_buy(self, card, game)
+        game.effect_registry.on_buy(self, card, game, self.discard_pile)
         logger.info(f"{self} buys {card}")
 
     def gain(
@@ -273,7 +273,7 @@ class Player:
         gain_card = source.remove(card)
         destination.add(gain_card)
         self.current_turn_gains.append((game.current_phase, card))
-        game.effect_registry.on_gain(self, card, game)
+        game.effect_registry.on_gain(self, card, game, destination)
         logger.info(f"{self} gains {gain_card}")
 
     def try_gain(

--- a/tests/test_cards/test_actions/test_bandit.py
+++ b/tests/test_cards/test_actions/test_bandit.py
@@ -7,7 +7,7 @@ def test_bandit_gains_gold(multiplayer_game: Game):
     player = multiplayer_game.players[0]
     player.hand.add(bandit)
     assert len(player.hand) == 6
-    player.hand.cards[-1].play(player, multiplayer_game)
+    player.play(bandit, multiplayer_game)
     assert len(player.hand) == 5
     assert len(player.playmat) == 1
     assert type(player.playmat.cards[0]) is Bandit
@@ -25,13 +25,16 @@ def test_bandit_trash_one_silver(multiplayer_game: Game):
     opponent.deck.add(silver)
     assert len(opponent.discard_pile) == 0
     assert len(multiplayer_game.trash) == 0
-    player.hand.cards[-1].play(player, multiplayer_game)
+    player.play(bandit, multiplayer_game)
     assert len(multiplayer_game.trash) == 1
     assert type(multiplayer_game.trash.cards[0]) is Silver
     assert len(opponent.discard_pile) == 1
 
 
-def test_bandit_trash_silver_over_gold(multiplayer_game: Game):
+def test_bandit_trash_silver_over_gold(multiplayer_game: Game, monkeypatch):
+    responses = ["Silver"]
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop())
+
     player = multiplayer_game.players[0]
     opponent = multiplayer_game.players[1]
     player.hand.add(bandit)
@@ -39,7 +42,7 @@ def test_bandit_trash_silver_over_gold(multiplayer_game: Game):
     opponent.deck.add(gold)
     assert len(opponent.discard_pile) == 0
     assert len(multiplayer_game.trash) == 0
-    player.hand.cards[-1].play(player, multiplayer_game)
+    player.play(bandit, multiplayer_game)
     assert len(multiplayer_game.trash) == 1
     assert type(multiplayer_game.trash.cards[0]) is Silver
     assert len(opponent.discard_pile) == 1
@@ -53,14 +56,14 @@ def test_bandit_discard_two_non_treasure(multiplayer_game: Game):
     opponent.deck.add(copper)
     assert len(opponent.discard_pile) == 0
     assert len(multiplayer_game.trash) == 0
-    player.hand.cards[-1].play(player, multiplayer_game)
+    player.play(bandit, multiplayer_game)
     assert len(multiplayer_game.trash) == 0
     assert len(opponent.discard_pile) == 2
 
 
 def test_bandit_empty_gold(multiplayer_game: Game):
     """
-    with an empty gold pile, playing witch should only trash opponents cards
+    with an empty gold pile, playing bandit should only trash opponent's cards
 
     """
 
@@ -71,7 +74,7 @@ def test_bandit_empty_gold(multiplayer_game: Game):
 
     player = multiplayer_game.players[0]
     player.hand.add(bandit)
-    player.hand.cards[-1].play(player, multiplayer_game)
+    player.play(bandit, multiplayer_game)
 
     assert len(player.discard_pile) == 0
     assert len(player.playmat) == 1

--- a/tests/test_cards/test_actions/test_courtier.py
+++ b/tests/test_cards/test_actions/test_courtier.py
@@ -57,3 +57,36 @@ def test_courtier_2_types_buy_gain_gold(human: Human, game: Game, monkeypatch):
     assert human.state.actions == 0
     assert human.state.buys == 2
     assert human.state.money == 0
+
+
+def test_courtier_empty_hand(human: Human, game: Game, monkeypatch):
+    human.hand.add(courtier)
+
+    responses = []
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
+
+    human.play(courtier, game)
+    assert len(human.hand) == 0
+    assert len(human.playmat) == 1
+    assert type(human.playmat.cards[0]) is Courtier
+    assert len(human.discard_pile) == 0
+    assert human.state.actions == 0
+    assert human.state.buys == 1
+    assert human.state.money == 0
+
+
+def test_courtier_1_card_hand(human: Human, game: Game, monkeypatch):
+    human.hand.add(courtier)
+    human.hand.add(copper)
+
+    responses = ["1"]
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
+
+    human.play(courtier, game)
+    assert len(human.hand) == 1
+    assert len(human.playmat) == 1
+    assert type(human.playmat.cards[0]) is Courtier
+    assert len(human.discard_pile) == 0
+    assert human.state.actions == 1
+    assert human.state.buys == 1
+    assert human.state.money == 0

--- a/tests/test_cards/test_actions/test_harbinger.py
+++ b/tests/test_cards/test_actions/test_harbinger.py
@@ -9,9 +9,22 @@ def test_harbinger_valid_topdeck(human: Human, game: Game, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "Silver")
 
-    human.hand.cards[0].play(human, game)
+    human.play(harbinger, game)
     assert len(human.hand) == 1
     assert len(human.playmat) == 1
     assert len(human.discard_pile) == 0
     assert human.state.actions == 1
     assert type(human.deck.cards[-1]) is Silver
+
+
+def test_harbinger_empty_discard_pile(human: Human, game: Game):
+    human.hand.add(harbinger)
+    assert len(human.discard_pile) == 0
+    assert len(human.deck) == 10
+
+    human.play(harbinger, game)
+    assert len(human.hand) == 1
+    assert len(human.playmat) == 1
+    assert len(human.discard_pile) == 0
+    assert len(human.deck) == 9
+    assert human.state.actions == 1

--- a/tests/test_cards/test_actions/test_library.py
+++ b/tests/test_cards/test_actions/test_library.py
@@ -1,4 +1,4 @@
-from pyminion.expansions.base import library, smithy
+from pyminion.expansions.base import copper, library, smithy
 from pyminion.game import Game
 from pyminion.human import Human
 
@@ -20,6 +20,23 @@ def test_library_skip_action(human: Human, game: Game, monkeypatch):
 
     human.play(library, game)
     assert len(human.hand) == 7
+    assert len(human.discard_pile) == 1
+    assert human.discard_pile.cards[0].name == "Smithy"
+
+
+def test_library_skip_action_small_deck(human: Human, game: Game, monkeypatch):
+    human.deck.cards.clear()
+    human.deck.add(copper)
+    human.deck.add(copper)
+    human.deck.add(smithy)
+
+    human.hand.add(library)
+    assert len(human.discard_pile) == 0
+
+    monkeypatch.setattr("builtins.input", lambda _: "yes")
+
+    human.play(library, game)
+    assert len(human.hand) == 2
     assert len(human.discard_pile) == 1
     assert human.discard_pile.cards[0].name == "Smithy"
 

--- a/tests/test_cards/test_actions/test_remodel.py
+++ b/tests/test_cards/test_actions/test_remodel.py
@@ -5,6 +5,7 @@ from pyminion.human import Human
 
 def test_remodel_gain_valid(human: Human, game: Game, monkeypatch):
     human.hand.add(copper)
+    human.hand.add(copper)
     human.hand.add(remodel)
     assert len(human.discard_pile) == 0
     assert len(game.trash) == 0
@@ -12,9 +13,39 @@ def test_remodel_gain_valid(human: Human, game: Game, monkeypatch):
     responses = iter(["copper", "estate"])
     monkeypatch.setattr("builtins.input", lambda input: next(responses))
 
-    human.hand.cards[-1].play(human, game)
+    human.play(remodel, game)
     assert len(human.playmat) == 1
     assert len(human.discard_pile) == 1
     assert human.state.actions == 0
     assert human.discard_pile.cards[0].name == "Estate"
     assert game.trash.cards[0].name == "Copper"
+
+
+def test_remodel_1_card_hand(human: Human, game: Game, monkeypatch):
+    human.hand.add(copper)
+    human.hand.add(remodel)
+    assert len(human.discard_pile) == 0
+    assert len(game.trash) == 0
+
+    responses = iter(["estate"])
+    monkeypatch.setattr("builtins.input", lambda input: next(responses))
+
+    human.play(remodel, game)
+    assert len(human.playmat) == 1
+    assert len(human.discard_pile) == 1
+    assert human.state.actions == 0
+    assert human.discard_pile.cards[0].name == "Estate"
+    assert game.trash.cards[0].name == "Copper"
+
+
+def test_remodel_empty_hand(human: Human, game: Game):
+    human.hand.add(remodel)
+    assert len(human.hand) == 1
+    assert len(human.discard_pile) == 0
+    assert len(game.trash) == 0
+
+    human.play(remodel, game)
+    assert len(human.playmat) == 1
+    assert len(human.discard_pile) == 0
+    assert len(game.trash) == 0
+    assert human.state.actions == 0

--- a/tests/test_cards/test_actions/test_replace.py
+++ b/tests/test_cards/test_actions/test_replace.py
@@ -1,6 +1,7 @@
 from pyminion.expansions.base import estate
 from pyminion.expansions.intrigue import Replace, intrigue_set, mill, replace
 from pyminion.game import Game
+from pyminion.player import Player
 import pytest
 
 def test_replace_gain_treasure(multiplayer_game: Game, monkeypatch):
@@ -74,3 +75,18 @@ def test_replace_gain_action_victory(multiplayer_game: Game, monkeypatch):
 
     assert len(p2.discard_pile) == 1
     assert p2.discard_pile.cards[0].name == "Curse"
+
+
+def test_replace_empty_hand(player: Player, game: Game, monkeypatch):
+    player.hand.add(replace)
+    assert len(player.hand) == 1
+
+    responses = []
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop())
+
+    player.play(replace, game)
+    assert len(player.hand) == 0
+    assert len(player.playmat) == 1
+    assert type(player.playmat.cards[0]) is Replace
+    assert len(player.discard_pile) == 0
+    assert len(game.trash) == 0

--- a/tests/test_cards/test_actions/test_sailor.py
+++ b/tests/test_cards/test_actions/test_sailor.py
@@ -1,4 +1,4 @@
-from pyminion.expansions.base import copper, curse, silver, throne_room
+from pyminion.expansions.base import artisan, base_set, copper, curse, silver, throne_room
 from pyminion.expansions.seaside import Sailor, bazaar, fishing_village, seaside_set, sailor
 from pyminion.game import Game
 import pytest
@@ -193,6 +193,35 @@ def test_two_sailors_play(multiplayer_game: Game, monkeypatch):
     assert len(responses) == 0
     assert len(human.playmat) == 4
     assert len(human.discard_pile) == 2
+
+
+@pytest.mark.expansions([base_set, seaside_set])
+@pytest.mark.kingdom_cards([artisan, fishing_village, sailor])
+def test_sailor_play_gain_deck(multiplayer_game: Game, monkeypatch):
+    responses = ["Fishing Village", "y", "Silver"]
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
+
+    human = multiplayer_game.players[0]
+    human.hand.add(silver)
+    human.hand.add(sailor)
+    human.hand.add(artisan)
+
+    human.play(sailor, multiplayer_game)
+
+    # play artisan to gain a duration card to player's hand, then play it with sailor
+    human.play(artisan, multiplayer_game)
+
+    # gain a duration card and play it
+    assert len(responses) == 0
+    assert len(human.playmat) == 3
+    assert human.playmat.cards[0].name == "Sailor"
+    assert human.playmat.cards[1].name == "Artisan"
+    assert human.playmat.cards[2].name == "Fishing Village"
+    assert len(human.discard_pile) == 0
+    assert human.deck.cards[-1].name == "Silver"
+    assert human.state.actions == 2
+    assert human.state.money == 1
+
 
 
 @pytest.mark.expansions([seaside_set])

--- a/tests/test_cards/test_actions/test_secret_passage.py
+++ b/tests/test_cards/test_actions/test_secret_passage.py
@@ -1,4 +1,4 @@
-from pyminion.expansions.base import silver
+from pyminion.expansions.base import copper, silver
 from pyminion.expansions.intrigue import SecretPassage, secret_passage
 from pyminion.game import Game
 from pyminion.human import Human
@@ -53,3 +53,41 @@ def test_secret_passage_bottom(human: Human, game: Game, monkeypatch):
     assert type(human.playmat.cards[0]) is SecretPassage
     assert len(human.deck) == 9
     assert human.deck.cards[0].name == "Silver"
+
+
+def test_secret_passage_no_ask(human: Human, game: Game, monkeypatch):
+    human.deck.cards.clear()
+    human.discard_pile.cards.clear()
+
+    human.hand.add(secret_passage)
+    human.hand.add(silver)
+
+    assert len(human.deck) == 0
+
+    responses = []
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
+
+    human.play(secret_passage, game)
+    assert len(human.hand) == 0
+    assert len(human.playmat) == 1
+    assert type(human.playmat.cards[0]) is SecretPassage
+    assert len(human.deck) == 1
+    assert human.deck.cards[0].name == "Silver"
+
+
+def test_secret_passage_no_cards(human: Human, game: Game, monkeypatch):
+    human.deck.cards.clear()
+    human.discard_pile.cards.clear()
+
+    human.hand.add(secret_passage)
+
+    assert len(human.deck) == 0
+
+    responses = []
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
+
+    human.play(secret_passage, game)
+    assert len(human.hand) == 0
+    assert len(human.playmat) == 1
+    assert type(human.playmat.cards[0]) is SecretPassage
+    assert len(human.deck) == 0

--- a/tests/test_cards/test_actions/test_swindler.py
+++ b/tests/test_cards/test_actions/test_swindler.py
@@ -1,5 +1,17 @@
-from pyminion.expansions.base import copper, moat
-from pyminion.expansions.intrigue import Swindler, swindler
+from pyminion.expansions.base import (
+    base_set,
+    artisan,
+    cellar,
+    copper,
+    festival,
+    market,
+    moat,
+    smithy,
+    vassal,
+    village,
+    witch,
+)
+from pyminion.expansions.intrigue import Swindler, intrigue_set, swindler
 from pyminion.game import Game
 import pytest
 
@@ -24,6 +36,9 @@ def test_swindler(multiplayer_game: Game, monkeypatch):
     assert len(p2.discard_pile) > 0
     assert p2.discard_pile.cards[-1].name == "Curse"
 
+    assert len(multiplayer_game.trash) == 1
+    assert multiplayer_game.trash.cards[0].name == "Copper"
+
 
 @pytest.mark.kingdom_cards([moat])
 def test_swindler_moat(multiplayer_game: Game, monkeypatch):
@@ -47,3 +62,35 @@ def test_swindler_moat(multiplayer_game: Game, monkeypatch):
 
     assert p2.deck.cards[-1].name == "Moat"
     assert len(p2.discard_pile) == 0
+
+    assert len(multiplayer_game.trash) == 0
+
+
+# create a kingdom with only one $4 cost card (smithy)
+@pytest.mark.expansions([base_set, intrigue_set])
+@pytest.mark.kingdom_cards([artisan, cellar, festival, market, moat, smithy, swindler, vassal, village, witch])
+def test_swindler_no_gain(multiplayer_game: Game, monkeypatch):
+    # empty smithy pile
+    multiplayer_game.supply.get_pile("Smithy").cards.clear()
+
+    players = multiplayer_game.players
+    p1 = players[0]
+    p2 = players[1]
+
+    p1.hand.add(swindler)
+    p2.deck.add(smithy)
+
+    responses = []
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
+
+    p1.play(swindler, multiplayer_game)
+    assert len(p1.hand) == 5
+    assert len(p1.playmat) == 1
+    assert type(p1.playmat.cards[0]) is Swindler
+    assert p1.state.actions == 0
+    assert p1.state.money == 2
+
+    assert len(p2.discard_pile) == 0
+
+    assert len(multiplayer_game.trash) == 1
+    assert multiplayer_game.trash.cards[0].name == "Smithy"

--- a/tests/test_cards/test_actions/test_upgrade.py
+++ b/tests/test_cards/test_actions/test_upgrade.py
@@ -36,3 +36,20 @@ def test_upgrade_no_gain(human: Human, game: Game, monkeypatch):
     assert type(game.trash.cards[0]) is Copper
     assert len(human.discard_pile) == 0
     assert human.state.actions == 1
+
+
+def test_upgrade_empty_hand(human: Human, game: Game, monkeypatch):
+    human.deck.cards.clear()
+    human.discard_pile.cards.clear()
+    human.hand.add(upgrade)
+
+    responses = []
+    monkeypatch.setattr("builtins.input", lambda _: responses.pop())
+
+    human.play(upgrade, game)
+    assert len(human.hand) == 0
+    assert len(human.playmat) == 1
+    assert type(human.playmat.cards[0]) is Upgrade
+    assert len(game.trash) == 0
+    assert len(human.discard_pile) == 0
+    assert human.state.actions == 1

--- a/tests/test_cards/test_actions/test_vassal.py
+++ b/tests/test_cards/test_actions/test_vassal.py
@@ -6,7 +6,7 @@ from pyminion.human import Human
 def test_vassal_not_action_play(human: Human, game: Game):
     human.hand.add(vassal)
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 0
     assert len(human.playmat) == 1
     assert len(human.discard_pile) == 1
@@ -20,7 +20,7 @@ def test_vassal_no_play(human: Human, game: Game, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "n")
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 0
     assert len(human.playmat) == 1
     assert len(human.discard_pile) == 1
@@ -34,7 +34,7 @@ def test_vassal_play(human: Human, game: Game, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 3
     assert len(human.playmat) == 2
     assert len(human.discard_pile) == 0
@@ -43,13 +43,12 @@ def test_vassal_play(human: Human, game: Game, monkeypatch):
 
 
 def test_vassal_play_chain_two(human: Human, game: Game, monkeypatch):
-    # human.deck.add(vassal)
     human.deck.add(vassal)
     human.hand.add(vassal)
 
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 0
     assert len(human.playmat) == 2
     assert len(human.discard_pile) == 1
@@ -65,7 +64,7 @@ def test_vassal_play_chain_three(human: Human, game: Game, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 0
     assert len(human.playmat) == 3
     assert len(human.discard_pile) == 1
@@ -80,7 +79,7 @@ def test_vassal_play_chain_smithy(human: Human, game: Game, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 3
     assert len(human.playmat) == 2
     assert len(human.discard_pile) == 0
@@ -94,9 +93,23 @@ def test_vassal_play_chain_village(human: Human, game: Game, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "y")
 
-    human.hand.cards[0].play(human, game)
+    human.play(vassal, game)
     assert len(human.hand) == 1
     assert len(human.playmat) == 2
     assert len(human.discard_pile) == 0
     assert human.state.actions == 2
+    assert human.state.money == 2
+
+
+def test_vassal_no_cards(human: Human, game: Game):
+    human.deck.cards.clear()
+    human.discard_pile.cards.clear()
+    human.hand.add(vassal)
+
+    human.play(vassal, game)
+    assert len(human.hand) == 0
+    assert len(human.playmat) == 1
+    assert len(human.deck) == 0
+    assert len(human.discard_pile) == 0
+    assert human.state.actions == 0
     assert human.state.money == 2

--- a/tests/test_cards/test_treasures/test_farm.py
+++ b/tests/test_cards/test_treasures/test_farm.py
@@ -1,18 +1,18 @@
-from pyminion.expansions.intrigue import Harem, harem
+from pyminion.expansions.intrigue import Farm, farm
 from pyminion.game import Game
 from pyminion.player import Player
 
 
 def test_money(player: Player, game: Game):
-    player.hand.add(harem)
+    player.hand.add(farm)
 
-    harem.play(player, game)
+    farm.play(player, game)
     assert len(player.hand) == 0
     assert len(player.playmat) == 1
-    assert type(player.playmat.cards[0]) is Harem
+    assert type(player.playmat.cards[0]) is Farm
     assert player.state.money == 2
 
 
 def test_vp(player: Player):
-    player.hand.add(harem)
-    assert harem.score(player) == 2
+    player.hand.add(farm)
+    assert farm.score(player) == 2

--- a/tests/test_effects/test_effects.py
+++ b/tests/test_effects/test_effects.py
@@ -1,5 +1,5 @@
-from pyminion.core import Card
-from pyminion.effects import AttackEffect, Effect, EffectAction, EffectRegistry, FuncPlayerCardGameEffect, PlayerCardGameEffect, PlayerGameEffect
+from pyminion.core import AbstractDeck, Card
+from pyminion.effects import AttackEffect, Effect, EffectAction, EffectRegistry, FuncPlayerCardGameEffect, GainEffect, PlayerCardGameEffect, PlayerGameEffect
 from pyminion.expansions.base import gold, smithy, witch
 from pyminion.game import Game
 from pyminion.player import Player
@@ -37,6 +37,31 @@ class AttackEffectTest(AttackEffect):
         if self.order_counter is not None:
             self.order_count = self.order_counter.inc_count()
         return True
+
+
+class GainEffectTest(GainEffect):
+    def __init__(
+            self,
+            name: str = "PlayerCardGameEffectTest",
+            action: EffectAction = EffectAction.Other,
+            order_counter: Optional[OrderCounter] = None,
+    ):
+        super().__init__(name)
+        self._action = action
+        self.handler_called = False
+        self.order_counter = order_counter
+        self.order_count = -1
+
+    def get_action(self) -> EffectAction:
+        return self._action
+
+    def is_triggered(self, player: Player, card: Card, game: Game, destination: AbstractDeck) -> bool:
+        return True
+
+    def handler(self, player: Player, card: Card, game: Game, destination: AbstractDeck) -> None:
+        self.handler_called = True
+        if self.order_counter is not None:
+            self.order_count = self.order_counter.inc_count()
 
 
 class PlayerCardGameEffectTest(PlayerCardGameEffect):
@@ -113,9 +138,9 @@ def test_register_effects(effect_registry: EffectRegistry):
     assert len(effect_registry.cleanup_phase_start_effects) == 0
 
     effect_registry.register_attack_effect(AttackEffectTest())
-    effect_registry.register_buy_effect(PlayerCardGameEffectTest())
+    effect_registry.register_buy_effect(GainEffectTest())
     effect_registry.register_discard_effect(PlayerCardGameEffectTest())
-    effect_registry.register_gain_effect(PlayerCardGameEffectTest())
+    effect_registry.register_gain_effect(GainEffectTest())
     effect_registry.register_hand_add_effect(PlayerCardGameEffectTest())
     effect_registry.register_hand_remove_effect(PlayerCardGameEffectTest())
     effect_registry.register_play_effect(PlayerCardGameEffectTest())
@@ -160,9 +185,9 @@ def test_unregister_effects_by_id(effect_registry: EffectRegistry):
     assert len(effect_registry.cleanup_phase_start_effects) == 0
 
     attack_effect = AttackEffectTest()
-    buy_effect = PlayerCardGameEffectTest()
+    buy_effect = GainEffectTest()
     discard_effect = PlayerCardGameEffectTest()
-    gain_effect = PlayerCardGameEffectTest()
+    gain_effect = GainEffectTest()
     hand_add_effect = PlayerCardGameEffectTest()
     hand_remove_effect = PlayerCardGameEffectTest()
     play_effect = PlayerCardGameEffectTest()
@@ -392,8 +417,8 @@ def test_on_attack(multiplayer_game: Game):
 def test_on_buy(game: Game):
     reg = game.effect_registry
 
-    buy_effect = PlayerCardGameEffectTest()
-    gain_effect = PlayerCardGameEffectTest()
+    buy_effect = GainEffectTest()
+    gain_effect = GainEffectTest()
     reg.register_buy_effect(buy_effect)
     reg.register_gain_effect(gain_effect)
 
@@ -426,8 +451,8 @@ def test_on_discard(game: Game):
 def test_on_gain(game: Game):
     reg = game.effect_registry
 
-    buy_effect = PlayerCardGameEffectTest()
-    gain_effect = PlayerCardGameEffectTest()
+    buy_effect = GainEffectTest()
+    gain_effect = GainEffectTest()
     reg.register_buy_effect(buy_effect)
     reg.register_gain_effect(gain_effect)
 

--- a/tests/test_players/test_bots/test_optimized_bot.py
+++ b/tests/test_players/test_bots/test_optimized_bot.py
@@ -3,6 +3,7 @@ from pyminion.core import CardType, DeckCounter
 from pyminion.expansions.base import (
     Smithy,
     artisan,
+    bandit,
     base_set,
     bureaucrat,
     cellar,
@@ -310,6 +311,21 @@ def test_remodel_bot_gold(bot: OptimizedBot, game: Game):
     bot.hand.add(gold)
     bot.play(remodel, game)
     assert bot.discard_pile.cards[-1].name == "Province"
+
+
+def test_bandit_bot(multiplayer_bot_game: Game):
+    p1 = multiplayer_bot_game.players[0]
+    p2 = multiplayer_bot_game.players[1]
+
+    p1.hand.add(bandit)
+
+    p2.deck.add(gold)
+    p2.deck.add(silver)
+
+    p1.play(bandit, multiplayer_bot_game)
+
+    assert p2.discard_pile.cards[-1].name == "Gold"
+    assert multiplayer_bot_game.trash.cards[0].name == "Silver"
 
 
 def test_sentry_bot_no_response(bot: OptimizedBot, game: Game):

--- a/tests/test_players/test_bots/test_optimized_bot.py
+++ b/tests/test_players/test_bots/test_optimized_bot.py
@@ -302,12 +302,14 @@ def test_bot_one_empty_pile_prioritize_victory(bot: OptimizedBot, game: Game):
 def test_remodel_bot(bot: OptimizedBot, game: Game):
     bot.hand.add(remodel)
     bot.hand.add(copper)
+    bot.hand.add(copper)
     bot.play(remodel, game)
     assert bot.discard_pile.cards[-1].name == "Estate"
 
 
 def test_remodel_bot_gold(bot: OptimizedBot, game: Game):
     bot.hand.add(remodel)
+    bot.hand.add(gold)
     bot.hand.add(gold)
     bot.play(remodel, game)
     assert bot.discard_pile.cards[-1].name == "Province"


### PR DESCRIPTION
Various bug fixes and improvements including the following:

* Fixed Optimized Bot logic for Artisan and Workshop to not try to gain from an empty pile
* Big Money bot should do nothing for actions (even though Big Money bot doesn't buy actions itself, there are situations where another player can give it actions)
* Several cards needed to check for an empty hand: Remodel, Replace, Secret Passage, Sentry, and Upgrade
* Masquerade did not call the correct player decider
* Bandit now asks opponent for which treasure to trash
* [Farm](https://wiki.dominionstrategy.com/index.php/Farm) rename
* Fixed a Library bug when skipping actions when deck and discard pile were empty
* Sailor now allows playing Durations when gained to other places than discard pile